### PR TITLE
Remove quickSort

### DIFF
--- a/Stdlib/Data/List.juvix
+++ b/Stdlib/Data/List.juvix
@@ -101,15 +101,4 @@ null : {A : Type} → List A → Bool;
 null nil ≔ true;
 null _ ≔ false;
 
-qsHelper : {A : Type} → A → List A × List A → List A;
-qsHelper a (l , r) ≔ l ++ (a ∷ nil) ++ r;
-
-terminating
-quickSort : {A : Type} → (A → A → Ordering) → List A → List A;
-quickSort _ nil ≔ nil;
-quickSort _ (x ∷ nil) ≔ x ∷ nil;
-quickSort cmp (x ∷ xs) ≔
-   qsHelper x
-   (both (quickSort cmp) (partition (isLT ∘ cmp x) xs));
-
 end;


### PR DESCRIPTION
Temporary fix for Juvix issue [#1382](https://github.com/anoma/juvix/issues/1382). Fixing Juvix issue [#1341](https://github.com/anoma/juvix/issues/1341) depends on this.
