### PR TITLE
Remove Int type

### DIFF
--- a/Stdlib/Data/Nat.juvix
+++ b/Stdlib/Data/Nat.juvix
@@ -46,52 +46,9 @@ eight ≔ suc seven;
 nine : ℕ;
 nine ≔ suc eight;
 
---------------------------------------------------------------------------------
--- Int
---------------------------------------------------------------------------------
-
-axiom Int : Type;
-compile Int {
-  c ↦ "int";
-};
-
-foreign c {
-   int plus(int l, int r) {
-     return l + r;
-   \}
-};
-
-infix 6 +int;
-axiom +int : Int -> Int -> Int;
-compile +int {
-  c ↦ "plus";
-};
-
-foreign c {
-  int natInd(int n, int a1, juvix_function_t* a2) {
-    if (n <= 0) return a1;
-    return ((int (*) (juvix_function_t*, int))a2->fun)(a2, natInd(n - 1, a1, a2));
-  \}
-};
-
-axiom natInd : Int → ℕ → (ℕ → ℕ) → ℕ;
-compile natInd {
-  c ↦ "natInd";
-};
-
-from-backendNat : Int → ℕ;
-from-backendNat bb ≔ natInd bb zero suc;
-
-axiom intToStr : Int → String;
-compile intToStr {
+axiom natToStr : ℕ → String;
+compile natToStr {
   c ↦ "intToStr";
 };
-
-natToInt : ℕ → Int;
-natToInt zero ≔ 0;
-natToInt (suc n) ≔ 1 +int (natToInt n);
-
-natToStr : ℕ → String;
-natToStr n ≔ intToStr (natToInt n);
 
 end;

--- a/Stdlib/Data/String/Ord.juvix
+++ b/Stdlib/Data/String/Ord.juvix
@@ -11,7 +11,7 @@ foreign c {
 
 axiom eqString : String → String → BackendBool;
 compile eqString  {
-  c ↦ "eqString";
+  c ↦ "cStrEq";
 };
 
 infix 4 ==;


### PR DESCRIPTION
We don't want to include an `Int` type in the standard library before we have support for arbitrary precision numbers https://github.com/anoma/juvix/issues/1356

The `SimpleFungibleToken` example juvix program requires an Int type - we will include it inside that project for now.

This PR also fixes the `eqString` axiom which had an incorrect compile block reference.