### PR TITLE
CI: Install LLVM before build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,21 @@ jobs:
           enable-stack: true
           stack-version: 'latest'
 
+      - name: Cache LLVM and Clang
+        id: cache-llvm
+        uses: actions/cache@v3
+        with:
+          path: |
+            C:/Program Files/LLVM
+            ./llvm
+          key: ${{ runner.os }}-llvm-13
+
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "13.0"
+          cached: ${{ steps.cache-llvm.outputs.cache-hit }}
+
       - name: Checkout Juvix
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
The Juvix build depends on LLVM tools for building the runtime.

This is the reason why CI is currently failing for PRs: https://github.com/anoma/juvix-stdlib/actions/runs/3592093350/jobs/6047401613