### PR TITLE
Pin CI OS to ubuntu-20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        ghc: ["9.2.3"]
+        os: [ubuntu-20.04]
+        ghc: ["9.2.5"]
     steps:
       - uses: actions/cache@v3
         name: Cache Stack


### PR DESCRIPTION
There's an issue with libtinfo5 not being available on ubuntu-22.04.

This also bumps the haskell action ghc version to 9.2.5, though ghc is installed by stack.