### PR TITLE
Make String a builtin and add print* variants with terminating newlines

### DIFF
--- a/Stdlib/Data/String.juvix
+++ b/Stdlib/Data/String.juvix
@@ -1,11 +1,5 @@
 module Stdlib.Data.String;
 
-open import Stdlib.Data.Bool;
-
-axiom String : Type;
-
-compile String {
-  c ↦ "char*";
-};
+builtin string axiom String : Type;
 
 end;

--- a/Stdlib/System/IO.juvix
+++ b/Stdlib/System/IO.juvix
@@ -8,6 +8,7 @@ builtin IO axiom IO : Type;
 infixl 1 >>;
 builtin IO-sequence axiom >> : IO → IO → IO;
 builtin nat-print axiom printNat : Nat → IO;
+builtin string-print axiom printString : String → IO;
 
 axiom putStr : String → IO;
 compile putStr {

--- a/Stdlib/System/IO.juvix
+++ b/Stdlib/System/IO.juvix
@@ -12,6 +12,15 @@ builtin nat-print axiom printNat : Nat → IO;
 builtin string-print axiom printString : String → IO;
 builtin bool-print axiom printBool : Bool → IO;
 
+printNatLn : Nat → IO;
+printNatLn n := printNat n >> printString "\n";
+
+printStringLn : String → IO;
+printStringLn s := printString s >> printString "\n";
+
+printBoolLn : Bool → IO;
+printBoolLn b := printBool b >> printString "\n";
+
 axiom putStr : String → IO;
 compile putStr {
   c ↦ "putStr";

--- a/Stdlib/System/IO.juvix
+++ b/Stdlib/System/IO.juvix
@@ -2,6 +2,7 @@ module Stdlib.System.IO;
 
 open import Stdlib.Data.Nat;
 open import Stdlib.Data.String;
+open import Stdlib.Data.Bool;
 
 builtin IO axiom IO : Type;
 
@@ -9,6 +10,7 @@ infixl 1 >>;
 builtin IO-sequence axiom >> : IO → IO → IO;
 builtin nat-print axiom printNat : Nat → IO;
 builtin string-print axiom printString : String → IO;
+builtin bool-print axiom printBool : Bool → IO;
 
 axiom putStr : String → IO;
 compile putStr {


### PR DESCRIPTION
The juvix repo points to a revision of juvix-stdlib that contains these commits. I somehow forgot to PR this.