### PR TITLE
Add functions to `Stdlib.Data.List`

### DIFF
--- a/Stdlib/Data/List.juvix
+++ b/Stdlib/Data/List.juvix
@@ -170,8 +170,8 @@ zipWith {A} {B} {C} f as bs :=
     go : List A -> List B -> List C -> List C;
     go _ nil acc := acc;
     go nil _ acc := acc;
-    go (a :: az) (b :: bz) acc := go az bz (snoc acc (f a b));
-  in go as bs nil;
+    go (a :: az) (b :: bz) acc := go az bz (f a b :: acc);
+  in reverse (go as bs nil);
 
 --- 𝒪(min(𝓂, 𝓃)). Returns a list of pairs formed from the input lists.
 zip :
@@ -185,8 +185,8 @@ zip {A} {B} as bs :=
     go : List A -> List B -> List (A × B) -> List (A × B);
     go _ nil acc := acc;
     go nil _ acc := acc;
-    go (a :: az) (b :: bz) acc := go az bz (snoc acc (a, b));
-  in go as bs nil;
+    go (a :: az) (b :: bz) acc := go az bz ((a, b) :: acc);
+  in reverse (go as bs nil);
 
 --- 𝒪(𝓃 log 𝓃). Sorts a list of elements in ascending order using the MergeSort
 --- algorithm.
@@ -221,7 +221,5 @@ quickSort {A} cmp :=
     go nil := nil;
     go xs@(_ :: nil) := xs;
     go (x :: xs) :=
-      qsHelper
-        x
-        (both go (partition (isGT ∘ cmp x) xs));
+      qsHelper x (both go (partition (isGT ∘ cmp x) xs));
   in go;

--- a/Stdlib/Data/List.juvix
+++ b/Stdlib/Data/List.juvix
@@ -96,8 +96,8 @@ partition _ nil := nil, nil;
 partition f (x :: xs) :=
   if (f x) first second ((::) x) (partition f xs);
 
---- Concatenates two ;List;s.
 infixr 5 ++;
+--- Concatenates two ;List;s.
 ++ : {A : Type} → List A → List A → List A;
 ++ nil ys := ys;
 ++ (x :: xs) ys := x :: xs ++ ys;
@@ -145,3 +145,30 @@ all f xs := foldl and true (map f xs);
 null : {A : Type} → List A → Bool;
 null nil := true;
 null _ := false;
+
+--- 𝓞(min(𝓶, 𝓷)). Returns a list containing the results of applying a function
+--- to each pair of elements from the input lists.
+zipWith :
+  {A : Type}
+    -> {B : Type}
+    -> {C : Type}
+    -> (A -> B -> C)
+    -> List A
+    -> List B
+    -> List C;
+zipWith {A} {B} {C} f as bs :=
+  let
+    go : List A -> List B -> List C;
+    go _ nil := nil;
+    go nil _ := nil;
+    go (a :: az) (b :: bz) := f a b :: go az bz;
+  in go as bs;
+
+--- 𝓞(min(𝓶, 𝓷)). Returns a list of pairs formed from the input lists.
+zip :
+  {A : Type}
+    -> {B : Type}
+    -> List A
+    -> List B
+    -> List (A × B);
+zip := zipWith (,);

--- a/Stdlib/Data/List.juvix
+++ b/Stdlib/Data/List.juvix
@@ -64,6 +64,11 @@ take : {A : Type} → Nat → List A → List A;
 take (suc n) (x :: xs) := x :: take n xs;
 take _ _ := nil;
 
+--- Drops the first n elements of a ;List;.
+drop : {A : Type} → Nat → List A → List A;
+drop (suc n) (x :: xs) := drop n xs;
+drop _ xs := xs;
+
 --- 𝒪(𝓃). splitAt n xs returns a tuple where first element is xs
 --- prefix of length n and second element is the remainder of the ;List;.
 splitAt : {A : Type} → Nat → List A → List A × List A;

--- a/Stdlib/Data/List.juvix
+++ b/Stdlib/Data/List.juvix
@@ -107,6 +107,10 @@ infixr 5 ++;
 ++ nil ys := ys;
 ++ (x :: xs) ys := x :: xs ++ ys;
 
+--- 𝒪(𝓃). Append an element.
+snoc : {A : Type} -> List A -> A -> List A;
+snoc xs x := xs ++ x :: nil;
+
 --- Concatenates a ;List; of ;List;s.
 flatten : {A : Type} → List (List A) → List A;
 flatten := foldl (++) nil;

--- a/Stdlib/Data/List.juvix
+++ b/Stdlib/Data/List.juvix
@@ -167,11 +167,11 @@ zipWith :
     -> List C;
 zipWith {A} {B} {C} f as bs :=
   let
-    go : List A -> List B -> List C;
-    go _ nil := nil;
-    go nil _ := nil;
-    go (a :: az) (b :: bz) := f a b :: go az bz;
-  in go as bs;
+    go : List A -> List B -> List C -> List C;
+    go _ nil acc := acc;
+    go nil _ acc := acc;
+    go (a :: az) (b :: bz) acc := go az bz (snoc acc (f a b));
+  in go as bs nil;
 
 --- 𝒪(min(𝓂, 𝓃)). Returns a list of pairs formed from the input lists.
 zip :
@@ -180,4 +180,10 @@ zip :
     -> List A
     -> List B
     -> List (A × B);
-zip := zipWith (,);
+zip {A} {B} as bs :=
+  let
+    go : List A -> List B -> List (A × B) -> List (A × B);
+    go _ nil acc := acc;
+    go nil _ acc := acc;
+    go (a :: az) (b :: bz) acc := go az bz (snoc acc (a, b));
+  in go as bs nil;

--- a/Stdlib/Data/List.juvix
+++ b/Stdlib/Data/List.juvix
@@ -155,7 +155,7 @@ null : {A : Type} → List A → Bool;
 null nil := true;
 null _ := false;
 
---- 𝓞(min(𝓶, 𝓷)). Returns a list containing the results of applying a function
+--- 𝒪(min(𝓂, 𝓃)). Returns a list containing the results of applying a function
 --- to each pair of elements from the input lists.
 zipWith :
   {A : Type}
@@ -173,7 +173,7 @@ zipWith {A} {B} {C} f as bs :=
     go (a :: az) (b :: bz) := f a b :: go az bz;
   in go as bs;
 
---- 𝓞(min(𝓶, 𝓷)). Returns a list of pairs formed from the input lists.
+--- 𝒪(min(𝓂, 𝓃)). Returns a list of pairs formed from the input lists.
 zip :
   {A : Type}
     -> {B : Type}

--- a/Stdlib/Data/List.juvix
+++ b/Stdlib/Data/List.juvix
@@ -137,6 +137,10 @@ transpose xss := map head xss :: transpose (map tail xss);
 any : {A : Type} → (A → Bool) → List A → Bool;
 any f xs := foldl or false (map f xs);
 
+--- 𝒪(𝓃). Returns ;true; if all elements of the ;List; satisfy the predicate.
+all : {A : Type} -> (A -> Bool) -> List A -> Bool;
+all f xs := foldl and true (map f xs);
+
 --- 𝒪(1). Returns ;true; if the ;List; is empty.
 null : {A : Type} → List A → Bool;
 null nil := true;

--- a/Stdlib/Data/List.juvix
+++ b/Stdlib/Data/List.juvix
@@ -207,8 +207,8 @@ mergeSort {A} cmp :=
       in merge cmp (go left) (go right);
   in go;
 
---- 𝒪(𝓃²). Sorts a list of elements in ascending order using te QuickSort
---- algorithm.
+--- On average 𝒪(𝓃 log 𝓃), worst case 𝒪(𝓃²). Sorts a list of elements in
+--- ascending order using te QuickSort algorithm.
 terminating
 quickSort :
   {A : Type} → (A → A → Ordering) → List A → List A;

--- a/Stdlib/Data/List.juvix
+++ b/Stdlib/Data/List.juvix
@@ -187,3 +187,41 @@ zip {A} {B} as bs :=
     go nil _ acc := acc;
     go (a :: az) (b :: bz) acc := go az bz (snoc acc (a, b));
   in go as bs nil;
+
+--- 𝒪(𝓃 log 𝓃). Sorts a list of elements in ascending order using the MergeSort
+--- algorithm.
+mergeSort :
+  {A : Type} → (A → A → Ordering) → List A → List A;
+mergeSort {A} cmp :=
+  let
+    terminating
+    go : List A -> List A;
+    go nil := nil;
+    go xs@(_ :: nil) := xs;
+    go xs :=
+      let
+        splitXs :
+            List A × List A := splitAt (div (length xs) 2) xs;
+        left : List A := fst splitXs;
+        right : List A := snd splitXs;
+      in merge cmp (go left) (go right);
+  in go;
+
+--- 𝒪(𝓃²). Sorts a list of elements in ascending order using te QuickSort
+--- algorithm.
+terminating
+quickSort :
+  {A : Type} → (A → A → Ordering) → List A → List A;
+quickSort {A} cmp :=
+  let
+    qsHelper : {A : Type} → A → List A × List A → List A;
+    qsHelper a (l, r) := l ++ (a :: nil) ++ r;
+    terminating
+    go : List A → List A;
+    go nil := nil;
+    go xs@(_ :: nil) := xs;
+    go (x :: xs) :=
+      qsHelper
+        x
+        (both go (partition (isGT ∘ cmp x) xs));
+  in go;

--- a/Stdlib/Data/Product.juvix
+++ b/Stdlib/Data/Product.juvix
@@ -6,14 +6,26 @@ infixr 4 ,;
 type × (A : Type) (B : Type) :=
   | , : A → B → A × B;
 
+--- Converts a function of two arguments to a function with a product argument.
 uncurry :
   {A : Type}
-    → {B : Type}
-    → {C : Type}
-    → (A → B → C)
-    → A × B
-    → C;
+    -> {B : Type}
+    -> {C : Type}
+    -> (A -> B -> C)
+    -> A × B
+    -> C;
 uncurry f (a, b) := f a b;
+
+--- Converts a function with a product argument to a function of two arguments.
+curry :
+  {A : Type}
+    -> {B : Type}
+    -> {C : Type}
+    -> (A × B -> C)
+    -> A
+    -> B
+    -> C;
+curry f a b := f (a, b);
 
 --- Projects the first component of a tuple.
 fst : {A : Type} → {B : Type} → A × B → A;

--- a/Stdlib/Function.juvix
+++ b/Stdlib/Function.juvix
@@ -61,24 +61,3 @@ infixl 1 >>>;
 builtin seq
 >>> : {A B : Type} → A → B → B;
 >>> x y := y;
-
---- Converts a function of two arguments to a function with a product argument.
-uncurry :
-  {A : Type}
-    -> {B : Type}
-    -> {C : Type}
-    -> (A -> B -> C)
-    -> A × B
-    -> C;
-uncurry f (a, b) := f a b;
-
---- Converts a function with a product argument to a function of two arguments.
-curry :
-  {A : Type}
-    -> {B : Type}
-    -> {C : Type}
-    -> (A × B -> C)
-    -> A
-    -> B
-    -> C;
-curry f a b := f (a, b);

--- a/Stdlib/Function.juvix
+++ b/Stdlib/Function.juvix
@@ -1,6 +1,7 @@
 module Stdlib.Function;
 
 open import Stdlib.Data.Nat;
+open import Stdlib.Data.Product;
 
 infixr 9 ∘;
 --- Function composition.
@@ -60,3 +61,24 @@ infixl 1 >>>;
 builtin seq
 >>> : {A B : Type} → A → B → B;
 >>> x y := y;
+
+--- Converts a function of two arguments to a function with a product argument.
+uncurry :
+  {A : Type}
+    -> {B : Type}
+    -> {C : Type}
+    -> (A -> B -> C)
+    -> A × B
+    -> C;
+uncurry f (a, b) := f a b;
+
+--- Converts a function with a product argument to a function of two arguments.
+curry :
+  {A : Type}
+    -> {B : Type}
+    -> {C : Type}
+    -> (A × B -> C)
+    -> A
+    -> B
+    -> C;
+curry f a b := f (a, b);

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,7 +3,10 @@ all: test
 
 deps/quickcheck:
 	@mkdir -p deps/
-	@git clone --branch v0.2.0 --depth 1 https://github.com/anoma/juvix-quickcheck.git deps/quickcheck
+	@git clone https://github.com/anoma/juvix-quickcheck.git deps/quickcheck
+	@git -C deps/quickcheck checkout 2a23d8ed14d171fecf95892da401ddd37f96d40a
+	@mkdir -p deps/quickcheck/deps/stdlib
+	@rsync -av ../* deps/quickcheck/deps/stdlib --exclude "test"
 
 build/Test: $(shell find ../ -name "*.juvix") $(wildcard deps/**/*.juvix) Test.juvix deps/quickcheck
 	@mkdir -p build

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,7 +5,7 @@ deps/quickcheck:
 	@mkdir -p deps/
 	@git clone --branch v0.2.0 --depth 1 https://github.com/anoma/juvix-quickcheck.git deps/quickcheck
 
-build/Test: Test.juvix deps/quickcheck
+build/Test: $(shell find ../ -name "*.juvix") $(wildcard deps/**/*.juvix) Test.juvix deps/quickcheck
 	@mkdir -p build
 	juvix compile -o build/Test Test.juvix
 

--- a/test/Test.juvix
+++ b/test/Test.juvix
@@ -4,6 +4,7 @@ open import Stdlib.Prelude hiding {+};
 
 import Stdlib.Data.Nat.Ord as Nat;
 import Stdlib.Data.Nat as Nat;
+import Stdlib.Data.Ord as Ord;
 
 open import Stdlib.Data.Int.Ord;
 open import Stdlib.Data.Int;
@@ -55,6 +56,110 @@ prop-add-sub-bad a b := a == 2;
 
 prop-gcd-bad : Int -> Int -> Bool;
 prop-gcd-bad a b := gcd a b > 1;
+
+prop-equal-compare-to-eq : Nat -> Bool;
+prop-equal-compare-to-eq a := Ord.isEQ (Nat.compare a a);
+
+prop-sort : (List Int -> List Int) -> List Int -> Bool;
+prop-sort sort xs :=
+   let
+     sorted : List Int := sort xs;
+     isSorted : List Int -> Bool;
+     isSorted nil := true;
+     isSorted (_ :: nil) := true;
+     isSorted (x :: y :: xs) := (x <= y) && isSorted (y :: xs);
+   in
+     length sorted Nat.== length xs
+     && eqListInt sorted (sort sorted)
+     && isSorted sorted;
+
+prop-zip : List Int -> List Int -> Bool;
+prop-zip xs ys :=
+  let
+    zs : List (Int × Int) := zip xs ys;
+    expectedLen : Nat := Nat.min (length xs) (length ys);
+  in length zs Nat.== expectedLen
+    && eqListInt (take expectedLen xs) (map fst zs)
+    && eqListInt (take expectedLen ys) (map snd zs);
+
+prop-zipWith :
+  (Int -> Int -> Int) -> List Int -> List Int -> Bool;
+prop-zipWith f xs ys :=
+  let
+    zs : List Int := zipWith f xs ys;
+    zsFlip : List Int := zipWith (flip f) ys xs;
+    expectedLen : Nat := Nat.min (length xs) (length ys);
+  in length zs Nat.== expectedLen
+    && eqListInt zs zsFlip
+    && eqListInt
+      (map
+        λ {
+          | x := f x x
+        }
+        xs)
+      (zipWith f xs xs);
+
+prop-snoc : List Int -> Int -> Bool;
+prop-snoc xs x :=
+  let
+    snoc-x : List Int := snoc xs x;
+  in eqListInt snoc-x (reverse (x :: reverse xs));
+
+prop-drop : Nat -> List Int -> Bool;
+prop-drop n xs :=
+  let
+    drop-n : List Int;
+    drop-n := drop n xs;
+  in
+    length drop-n Nat.<= length xs
+    && eqListInt (drop n (drop n xs)) (drop (2 Nat.* n) xs);
+
+sortTest : String -> (List Int -> List Int) -> QC.Test;
+sortTest sortName sort :=
+  QC.mkTest
+    (QC.testableFunction QC.argumentListInt QC.testableBool)
+    ("sort properties: " ++str sortName)
+    (prop-sort sort);
+
+dropTest : QC.Test;
+dropTest :=
+  QC.mkTest
+    (QC.testableFunction
+      QC.argumentNat
+      (QC.testableFunction
+        QC.argumentListInt QC.testableBool))
+    "drop properties"
+    prop-drop;
+
+snocTest : QC.Test;
+snocTest :=
+  QC.mkTest
+    (QC.testableFunction
+      QC.argumentListInt
+      (QC.testableFunction QC.argumentInt QC.testableBool))
+    "snoc properties"
+    prop-snoc;
+
+zipTest : QC.Test;
+zipTest :=
+  QC.mkTest
+    QC.testableListIntListInt
+    "zip properties"
+    prop-zip;
+
+zipWithTest : QC.Test;
+zipWithTest :=
+  QC.mkTest
+    QC.testableHofIntIntListIntListInt
+    "zipWith properties"
+    prop-zipWith;
+
+equalCompareToEqTest : QC.Test;
+equalCompareToEqTest :=
+  QC.mkTest
+    (QC.testableFunction QC.argumentNat QC.testableBool)
+    "equal Nats compare to EQ"
+    prop-equal-compare-to-eq;
 
 gcdNoCoprimeTest : QC.Test;
 gcdNoCoprimeTest :=
@@ -126,5 +231,12 @@ main :=
             :: splitAtRecombineTest
             :: mergeSumLengthsTest
             :: tailLengthOneLessTest
+            :: equalCompareToEqTest
+            :: zipTest
+            :: zipWithTest
+            :: snocTest
+            :: dropTest
+            :: (sortTest "mergeSort" (mergeSort compare))
+            :: (sortTest "quickSort" (quickSort compare))
             :: nil)
     };


### PR DESCRIPTION
This PR adds some functions that were defined in the quickcheck project into the standard library.

* `drop : {A : Type} → Nat → List A → List A`
* `snoc : {A : Type} -> List A -> A -> List A`
* `all : {A : Type} -> (A -> Bool) -> List A -> Bool`
* `zipWith : {A : Type} -> {B : Type} -> {C : Type} -> (A -> B -> C) -> List A -> List B -> List C`
* `zip : {A : Type} -> {B : Type} -> List A -> List B -> List (A × B)`
* `mergeSort : {A : Type} → (A → A → Ordering) → List A → List A`
* `quickSort : {A : Type} → (A → A → Ordering) → List A → List A`

In addition this PR adds a curry function to `Stdlib.Data.Product`.

Property tests are added.

The quickcheck library uses both the standard library and copies of these functions and so it must temporarily be pinned to a specific commit that does not contain the new functions.