### PR TITLE
Fix and test for splitAt function

### DIFF
--- a/Stdlib/Data/List/Base.juvix
+++ b/Stdlib/Data/List/Base.juvix
@@ -76,7 +76,7 @@ splitAt : {A : Type} → Nat → List A → List A × List A;
 splitAt _ nil := nil, nil;
 splitAt zero xs := nil, xs;
 splitAt (suc zero) (x :: xs) := x :: nil, xs;
-splitAt (suc (suc m)) (x :: xs) :=
+splitAt (suc m) (x :: xs) :=
   first ((::) x) (splitAt m xs);
 
 --- 𝒪(𝓃 + 𝓂). Merges two lists according the given ordering.

--- a/test/Test.juvix
+++ b/test/Test.juvix
@@ -32,6 +32,16 @@ prop-splitAtRecombine n xs :=
   case splitAt n xs
     | lhs, rhs := eqListInt xs (lhs ++ rhs);
 
+prop-splitAtLength : Nat -> List Int -> Bool;
+prop-splitAtLength n xs :=
+  case splitAt
+    n
+    -- Make sure the list has length at least n
+    (xs ++ replicate (sub n (length xs)) (ofNat 0))
+    | lhs, rhs :=
+      length lhs Nat.== n
+        && length rhs Nat.== sub (length xs) n;
+
 prop-mergeSumLengths : List Int -> List Int -> Bool;
 prop-mergeSumLengths xs ys :=
   length xs Nat.+ length ys
@@ -200,6 +210,13 @@ splitAtRecombineTest :=
     "splitAt: recombination of the output is equal to the input list"
     prop-splitAtRecombine;
 
+splitAtLengthTest : QC.Test;
+splitAtLengthTest :=
+  QC.mkTest
+    QC.testableNatListInt
+    "splitAt: Check lengths of output if the input Nat is greater than the length of the input list"
+    prop-splitAtLength;
+
 mergeSumLengthsTest : QC.Test;
 mergeSumLengthsTest :=
   QC.mkTest
@@ -226,6 +243,7 @@ main :=
             :: reverseLengthTest
             :: reverseReverseIdTest
             :: splitAtRecombineTest
+            :: splitAtLengthTest
             :: mergeSumLengthsTest
             :: tailLengthOneLessTest
             :: equalCompareToEqTest


### PR DESCRIPTION
There was a typo in the definition of `splitAt`:

https://github.com/anoma/juvix-stdlib/blob/c2a327139e9cd166e4e3241f4de192f375a94437/Stdlib/Data/List/Base.juvix#LL79C1-L80C1

So for example:

```
> splitAt 4 (1 :: 2 :: 3 :: 4 :: nil)
1 :: 2 :: nil , 3 :: 4 :: nil
```

This PR fixes `splitAt` and adds tests.