### PR TITLE
Replace the implementation of transpose

### DIFF
--- a/Stdlib/Data/List.juvix
+++ b/Stdlib/Data/List.juvix
@@ -19,12 +19,6 @@ head : {A : Type} → List A → A;
 head (x :: _) := x;
 head nil := fail "head: empty list";
 
---- 𝒪(𝓃 * 𝓂). Partial function that transposes a ;List; of ;List;s interpreted as a matrix.
-terminating
-transpose : {A : Type} → List (List A) → List (List A);
-transpose (nil :: _) := nil;
-transpose xss := map head xss :: transpose (map tail xss);
-
 module ListTraits;
   
   Eq : {A : Type} -> Eq A -> Eq (List A);

--- a/Stdlib/Data/List/Base.juvix
+++ b/Stdlib/Data/List/Base.juvix
@@ -218,3 +218,9 @@ catMaybes (nothing :: hs) := catMaybes hs;
 concatMap :
   {A B : Type} -> (A -> List B) -> List A -> List B;
 concatMap f := flatten ∘ map f;
+
+--- 𝒪(𝓃 * 𝓂). Transposes a ;List; of ;List;s interpreted as a matrix.
+transpose : {A : Type} -> List (List A) -> List (List A);
+transpose nil := nil;
+transpose (xs :: nil) := map (λ { x := x :: nil }) xs;
+transpose (xs :: xss) := zipWith (::) xs (transpose xss);

--- a/test/Test.juvix
+++ b/test/Test.juvix
@@ -13,6 +13,7 @@ open import Data.String;
 open import Data.Int;
 
 import Test.QuickCheckTest as QC;
+import Test.Arb as QC;
 
 prop-reverseDoesNotChangeLength : List Int -> Bool;
 prop-reverseDoesNotChangeLength xs :=
@@ -121,6 +122,27 @@ prop-drop n xs :=
     drop-n := drop n xs;
   in length drop-n Nat.<= length xs
     && eqListInt (drop n (drop n xs)) (drop (2 Nat.* n) xs);
+
+-- Assumption: The input list represents a rectangular matrix
+prop-transposeMatrixId : List (List Int) -> Bool;
+prop-transposeMatrixId xs :=
+  eq
+    (ListTraits.Eq (ListTraits.Eq (IntTraits.Eq)))
+    xs
+    (transpose (transpose xs));
+
+-- Assumption: The input list represents a rectangular matrix
+prop-transposeMatrixDimensions : List (List Int) -> Bool;
+prop-transposeMatrixDimensions xs :=
+  let txs : List (List Int) := transpose xs;
+      checkTxsRowXsCol : Bool := case xs
+         | (x :: _) := length txs Nat.== length x
+         | _ := null txs;
+      checkXsRowTxsCol : Bool := case txs
+         | (tx :: _) := length xs Nat.== length tx
+         | _ := null xs;
+   in
+     checkTxsRowXsCol && checkXsRowTxsCol;
 
 sortTest : String -> (List Int -> List Int) -> QC.Test;
 sortTest sortName sort :=
@@ -231,6 +253,20 @@ tailLengthOneLessTest :=
     "tail: length of output is one less than input unless empty"
     prop-tailLengthOneLess;
 
+transposeMatrixIdTest : QC.Test;
+transposeMatrixIdTest :=
+  QC.mkTest
+    (QC.testableFunction QC.argumentMatrixInt QC.testableBool)
+    "transpose: recrangular matrix has property transpose . transpose = id"
+    prop-transposeMatrixId;
+
+transposeMatrixDimentionsTest : QC.Test;
+transposeMatrixDimentionsTest :=
+  QC.mkTest
+    (QC.testableFunction QC.argumentMatrixInt QC.testableBool)
+    "transpose: transpose swaps dimensions"
+    prop-transposeMatrixDimensions;
+
 main : IO;
 main :=
   readLn
@@ -253,5 +289,7 @@ main :=
             :: dropTest
             :: sortTest "mergeSort" (mergeSort IntTraits.Ord)
             :: sortTest "quickSort" (quickSort IntTraits.Ord)
+            :: transposeMatrixIdTest
+            :: transposeMatrixDimentionsTest
             :: nil)
     };

--- a/test/Test/Arb.juvix
+++ b/test/Test/Arb.juvix
@@ -1,0 +1,50 @@
+module Test.Arb;
+
+open import Stdlib.Prelude;
+open import Test.QuickCheck;
+open import Test.QuickCheck.Arbitrary;
+open import Test.QuickCheck.Gen;
+open import Data.Random;
+
+arbitrarySizedList :
+  {A : Type} -> Nat -> Arbitrary A -> Arbitrary (List A);
+arbitrarySizedList {A} size (arbitrary g) :=
+  arbitrary
+    (gen
+      \ {
+        | rand :=
+          let
+            randList : StdGen -> Nat -> List A;
+            randList _ zero := nil;
+            randList r (suc n) :=
+              let
+                rSplit : StdGen × StdGen;
+                rSplit := stdSplit r;
+                r1 : StdGen := fst rSplit;
+                r2 : StdGen := snd rSplit;
+              in runGen g r1 :: randList r2 n;
+          in randList rand size
+      });
+
+--- Generate an arbitrary rectangular matrix
+arbitraryMatrix :
+  {A : Type} -> Arbitrary A -> Arbitrary (List (List A));
+arbitraryMatrix {A} arbA :=
+  arbitrary
+    (gen
+      \ {
+        | rand :=
+          let
+            randSplit : StdGen × StdGen := stdSplit rand;
+            rand1 : StdGen := fst randSplit;
+            rand2 : StdGen := snd randSplit;
+            cols : Nat := fst (randNat rand1 1 10);
+            arbRow : Arbitrary (List A) := arbitrarySizedList cols arbA;
+          in runArb (arbitraryList arbRow) rand2
+      });
+
+argumentMatrixInt : Argument (List (List Int));
+argumentMatrixInt :=
+  argument
+    (ListTraits.Show (ListTraits.Show IntTraits.Show))
+    (arbitraryMatrix arbitraryInt);


### PR DESCRIPTION
The old implementation of tranpose is partial and requires the terminating keyword. This commit replaces it with a non-partial version that passes the termination checker.

Property tests are also added for tranpose.