### PR TITLE
Add a Trait submodule to Stdlib.Prelude 

### DIFF
--- a/Stdlib/Prelude.juvix
+++ b/Stdlib/Prelude.juvix
@@ -17,3 +17,7 @@ import Stdlib.System.IO open public;
 import Stdlib.Trait.Ord open public;
 import Stdlib.Trait.Eq open public;
 import Stdlib.Trait.Show open public;
+
+module Trait;
+  import Stdlib.Trait open public;
+end;


### PR DESCRIPTION
After Juivx #2243 was merged implemnentors of stdlib traits must now add an
extra import statement and qualify the trait type in the type signature
of a trait implementation.

See
https://github.com/anoma/juvix-stdlib/blob/85751d3a7e5edd97a3d12dae197273731a2088cf/Stdlib/Data/Bool.juvix#L15

```
import Stdlib.Trait.Eq as Eq;

module BoolTraits;
  Eq : Eq.Eq Bool :=
```

The main problem with this approach is that it makes it more difficult
to document and discover how to implement traits. Previously the trait
type could be used directly from the `import Stdlib.Prelude` statement
that files usually have.

This will not be a problem when we have proper support for traits and
trait instances.

In the meantime @janmasrovira made the suggestion of adding a local
module to the Prelude so that users can write:

```
import Stdlib.Prelude open;

module BoolTraits;
  Eq : Trait.Eq Bool :=
```

This PR adds this module to the Prelude.