### PR TITLE
Add `Foldable` trait

### DIFF
--- a/Stdlib/Data/List.juvix
+++ b/Stdlib/Data/List.juvix
@@ -3,12 +3,14 @@ module Stdlib.Data.List;
 import Stdlib.Data.List.Base open public;
 import Stdlib.Data.Bool.Base open;
 import Stdlib.Data.String.Base open;
+import Stdlib.Function open;
 
 import Stdlib.Trait.Eq open;
 import Stdlib.Trait.Ord open;
 import Stdlib.Trait.Show open;
 import Stdlib.Trait.Functor open;
 import Stdlib.Trait.Partial open;
+import Stdlib.Trait.Foldable open using {Foldable; module Polymorphic; fromPolymorphicFoldable};
 
 --- 𝒪(1). Partial function that returns the first element of a ;List;.
 phead {A} {{Partial}} : List A -> A
@@ -59,3 +61,12 @@ functorListI : Functor List :=
 
 instance
 monomorphicFunctorListI {A} : Monomorphic.Functor (List A) A := fromPolymorphicFunctor;
+
+instance
+polymorphicFoldableListI : Polymorphic.Foldable List :=
+  Polymorphic.mkFoldable@{
+    foldl {A B} (g : B -> A -> B) : B -> List A -> B := foldr (flip g)
+  };
+
+instance
+foldableListI {A} : Foldable (List A) A := fromPolymorphicFoldable;

--- a/Stdlib/Data/List.juvix
+++ b/Stdlib/Data/List.juvix
@@ -65,7 +65,8 @@ monomorphicFunctorListI {A} : Monomorphic.Functor (List A) A := fromPolymorphicF
 instance
 polymorphicFoldableListI : Polymorphic.Foldable List :=
   Polymorphic.mkFoldable@{
-    foldl {A B} (g : B -> A -> B) : B -> List A -> B := foldr (flip g)
+    for := listFor;
+    rfor := listRfor
   };
 
 instance

--- a/Stdlib/Data/List/Base.juvix
+++ b/Stdlib/Data/List/Base.juvix
@@ -32,12 +32,12 @@ foldr {A B} (f : A → B → B) (z : B) : List A → B
   | nil := z
   | (h :: hs) := f h (foldr f z hs);
 
-syntax iterator rfor {init := 1; range := 1};
+syntax iterator listRfor {init := 1; range := 1};
 
 {-# specialize: [1] #-}
-rfor {A B} (f : B → A → B) (acc : B) : List A → B
+listRfor {A B} (f : B → A → B) (acc : B) : List A → B
   | nil := acc
-  | (x :: xs) := f (rfor f acc xs) x;
+  | (x :: xs) := f (listRfor f acc xs) x;
 
 --- Left-associative and tail-recursive fold.
 {-# specialize: [1] #-}
@@ -45,10 +45,10 @@ foldl {A B} (f : B → A → B) (z : B) : List A → B
   | nil := z
   | (h :: hs) := foldl f (f z h) hs;
 
-syntax iterator for {init := 1; range := 1};
+syntax iterator listFor {init := 1; range := 1};
 
 {-# inline: 0, isabelle-function: {name: "foldl"} #-}
-for : {A B : Type} → (B → A → B) → B → List A → B := foldl;
+listFor : {A B : Type} → (B → A → B) → B → List A → B := foldl;
 
 syntax iterator listMap {init := 0; range := 1};
 
@@ -68,11 +68,11 @@ filter {A} (f : A → Bool) : List A → List A
   | (h :: hs) := ite (f h) (h :: filter f hs) (filter f hs);
 
 --- 𝒪(𝓃). Returns the length of the ;List;.
-length {A} (l : List A) : Nat := for (acc := zero) (_ in l) {suc acc};
+length {A} (l : List A) : Nat := listFor (acc := zero) (_ in l) {suc acc};
 
 --- 𝒪(𝓃). Returns the given ;List; in reverse order.
 {-# isabelle-function: {name: "rev"} #-}
-reverse {A} (l : List A) : List A := for (acc := nil) (x in l) {x :: acc};
+reverse {A} (l : List A) : List A := listFor (acc := nil) (x in l) {x :: acc};
 
 --- Returns a ;List; of length n where every element is the given value.
 replicate {A} : Nat → A → List A

--- a/Stdlib/Data/List/Base.juvix
+++ b/Stdlib/Data/List/Base.juvix
@@ -28,9 +28,9 @@ find {A} (predicate : A → Bool) : List A → Maybe A
 
 --- Right-associative fold.
 {-# specialize: [1] #-}
-foldr {A B} (f : A → B → B) (z : B) : List A → B
+liftFoldr {A B} (f : A → B → B) (z : B) : List A → B
   | nil := z
-  | (h :: hs) := f h (foldr f z hs);
+  | (h :: hs) := f h (liftFoldr f z hs);
 
 syntax iterator listRfor {init := 1; range := 1};
 
@@ -41,14 +41,14 @@ listRfor {A B} (f : B → A → B) (acc : B) : List A → B
 
 --- Left-associative and tail-recursive fold.
 {-# specialize: [1] #-}
-foldl {A B} (f : B → A → B) (z : B) : List A → B
+listFoldl {A B} (f : B → A → B) (z : B) : List A → B
   | nil := z
-  | (h :: hs) := foldl f (f z h) hs;
+  | (h :: hs) := listFoldl f (f z h) hs;
 
 syntax iterator listFor {init := 1; range := 1};
 
 {-# inline: 0, isabelle-function: {name: "foldl"} #-}
-listFor : {A B : Type} → (B → A → B) → B → List A → B := foldl;
+listFor : {A B : Type} → (B → A → B) → B → List A → B := listFoldl;
 
 syntax iterator listMap {init := 0; range := 1};
 
@@ -125,7 +125,7 @@ snoc {A} (xs : List A) (x : A) : List A := xs ++ x :: nil;
 
 --- Concatenates a ;List; of ;List;s.
 {-# isabelle-function: {name: "concat"} #-}
-flatten : {A : Type} → List (List A) → List A := foldl (++) nil;
+flatten : {A : Type} → List (List A) → List A := listFoldl (++) nil;
 
 --- 𝒪(𝓃). Inserts the given element before every element in the given ;List;.
 prependToAll {A} (sep : A) : List A → List A

--- a/Stdlib/Data/Range.juvix
+++ b/Stdlib/Data/Range.juvix
@@ -35,7 +35,7 @@ to {N} {{Natural N}} (l h : N) : Range N := mkRange l h 1;
 
 syntax operator step step;
 
---- `x to y step s` is the range [x,x+s,..,y]
+--- `x to y step s` is the range [x, x + s, ..., y]
 {-# inline: always #-}
 step {N} (r : Range N) (s : N) : Range N := r@Range{step := s};
 
@@ -43,13 +43,22 @@ step {N} (r : Range N) (s : N) : Range N := r@Range{step := s};
 instance
 foldableRangeI {N} {{Ord N}} {{Natural N}} : Foldable (Range N) N :=
   mkFoldable@{
-    foldl {B : Type} (g : B -> N -> B) (ini : B) : Range N -> B
+    for {B : Type} (g : B -> N -> B) (ini : B) : Range N -> B
       | (mkRange low high step) :=
         let
           terminating
           go (acc : B) (next : N) : B :=
             if
-              | next <= high := go (g acc next) (low + step)
+              | next <= high := go (g acc next) (next + step)
               | else := acc;
+        in go ini low;
+    rfor {B : Type} (g : B -> N -> B) (ini : B) : Range N -> B
+      | (mkRange low high step) :=
+        let
+          terminating
+          go (base : B) (next : N) : B :=
+            if
+              | next <= high := g (go base (next + step)) next
+              | else := base;
         in go ini low
   };

--- a/Stdlib/Data/Range.juvix
+++ b/Stdlib/Data/Range.juvix
@@ -5,9 +5,10 @@ import Stdlib.Data.Fixity open;
 import Stdlib.Data.Bool.Base open;
 import Stdlib.Trait.Natural open;
 import Stdlib.Trait.Ord open;
+import Stdlib.Trait.Foldable open;
 import Stdlib.Data.Nat open;
 
---- A range of naturals
+--- An inclusive range of naturals
 type Range N :=
   mkRange {
     low : N;
@@ -37,3 +38,18 @@ syntax operator step step;
 --- `x to y step s` is the range [x,x+s,..,y]
 {-# inline: always #-}
 step {N} (r : Range N) (s : N) : Range N := r@Range{step := s};
+
+-- This instance assumes that (low + step*k > high) for some k.
+instance
+foldableRangeI {N} {{Ord N}} {{Natural N}} : Foldable (Range N) N :=
+  mkFoldable@{
+    foldl {B : Type} (g : B -> N -> B) (ini : B) : Range N -> B
+      | (mkRange low high step) :=
+        let
+          terminating
+          go (acc : B) (next : N) : B :=
+            if
+              | next <= high := go (g acc next) (low + step)
+              | else := acc;
+        in go ini low
+  };

--- a/Stdlib/Data/String/Base.juvix
+++ b/Stdlib/Data/String/Base.juvix
@@ -6,7 +6,7 @@ import Stdlib.Function open;
 import Stdlib.Data.Fixity open;
 
 --- Concatenates a ;List; of ;String;s.
-concatStr : List String -> String := foldl (++str) "";
+concatStr : List String -> String := listFoldl (++str) "";
 
 --- Joins a ;List; of ;String;s with "\n".
 unlines : List String -> String := intersperse "\n" >> concatStr;

--- a/Stdlib/Data/Unit.juvix
+++ b/Stdlib/Data/Unit.juvix
@@ -6,6 +6,7 @@ import Stdlib.Data.Bool.Base open;
 import Stdlib.Trait.Eq open;
 import Stdlib.Trait.Ord open;
 import Stdlib.Trait.Show open;
+import Stdlib.Trait.Foldable open;
 
 type Unit :=
   --- The only constructor of ;Unit;.
@@ -19,3 +20,10 @@ ordUnitI : Ord Unit := mkOrd λ {unit unit := EQ};
 
 instance
 showUnitI : Show Unit := mkShow λ {unit := "unit"};
+
+instance
+foldableUnitI : Foldable Unit Unit :=
+  mkFoldable@{
+    rfor {B : Type} (f : B -> Unit -> B) (ini : B) (_ : Unit) : B := f ini unit;
+    for {B : Type} (f : B -> Unit -> B) (ini : B) (_ : Unit) : B := f ini unit
+  };

--- a/Stdlib/Trait.juvix
+++ b/Stdlib/Trait.juvix
@@ -4,6 +4,7 @@ import Stdlib.Trait.Eq as Eq open using {Eq; module Eq} public;
 import Stdlib.Trait.Show as Show open using {Show; module Show} public;
 import Stdlib.Trait.Ord as Ord open using {Ord; module Ord} public;
 import Stdlib.Trait.Functor open public;
+import Stdlib.Trait.Foldable open public;
 import Stdlib.Trait.Partial open public;
 import Stdlib.Trait.Natural open public;
 import Stdlib.Trait.Integral open public;

--- a/Stdlib/Trait/Foldable.juvix
+++ b/Stdlib/Trait/Foldable.juvix
@@ -1,0 +1,4 @@
+module Stdlib.Trait.Foldable;
+
+import Stdlib.Trait.Foldable.Polymorphic as Polymorphic public;
+import Stdlib.Trait.Foldable.Monomorphic public;

--- a/Stdlib/Trait/Foldable.juvix
+++ b/Stdlib/Trait/Foldable.juvix
@@ -1,4 +1,4 @@
 module Stdlib.Trait.Foldable;
 
 import Stdlib.Trait.Foldable.Polymorphic as Polymorphic public;
-import Stdlib.Trait.Foldable.Monomorphic public;
+import Stdlib.Trait.Foldable.Monomorphic open public;

--- a/Stdlib/Trait/Foldable/Monomorphic.juvix
+++ b/Stdlib/Trait/Foldable/Monomorphic.juvix
@@ -6,8 +6,16 @@ import Stdlib.Trait.Foldable.Polymorphic as Poly;
 --- A trait for combining elements into a single result, processing one element at a time.
 trait
 type Foldable (container elem : Type) :=
-  mkFoldable {-- Combine the elements of the type using the provided function starting with the element in the left-most position.
-  foldl : {B : Type} -> (B -> elem -> B) -> B -> container -> B};
+  mkFoldable {
+    -- Combine the elements of the type using the provided function starting with the element in the left-most position.
+    syntax iterator for {init := 1; range := 1};
+    {-# inline: 0 #-}
+    for : {B : Type} -> (B -> elem -> B) -> B -> container -> B;
+
+    syntax iterator rfor {init := 1; range := 1};
+    {-# inline: 0 #-}
+    rfor : {B : Type} -> (B -> elem -> B) -> B → container → B
+  };
 
 open Foldable;
 
@@ -16,8 +24,18 @@ open Foldable;
 fromPolymorphicFoldable
   {f : Type -> Type} {{foldable : Poly.Foldable f}} {elem} : Foldable (f elem) elem :=
   mkFoldable@{
-    foldl : {B : Type} -> (B -> elem -> B) -> B -> f elem -> B := Poly.foldl
+    for := Poly.for;
+    rfor := Poly.rfor
   };
+
+foldl
+  {container elem}
+  {{Foldable container elem}}
+  {B : Type}
+  (g : B -> elem -> B)
+  (ini : B)
+  (ls : container)
+  : B := for (acc := ini) (x in ls) {g acc x};
 
 --- Combine the elements of the type using the provided function starting with the element in the right-most position.
 foldr
@@ -26,19 +44,3 @@ foldr
   {B : Type}
   (g : elem -> B -> B)
   : B -> container -> B := foldl (flip g);
-
-syntax iterator for {init := 1; range := 1};
-
-{-# inline: 0 #-}
-for
-  {container elem : Type}
-  {B}
-  {{Foldable container elem}}
-  : (B -> elem -> B) -> B -> container -> B := foldl;
-
-syntax iterator rfor {init := 1; range := 1};
-
-{-# inline: 0 #-}
-rfor
-  {container elem : Type} {B} {{Foldable container elem}} (i : B → elem → B) : B → container → B :=
-  foldr (flip i);

--- a/Stdlib/Trait/Foldable/Monomorphic.juvix
+++ b/Stdlib/Trait/Foldable/Monomorphic.juvix
@@ -7,7 +7,6 @@ import Stdlib.Trait.Foldable.Polymorphic as Poly;
 trait
 type Foldable (container elem : Type) :=
   mkFoldable {
-    -- Combine the elements of the type using the provided function starting with the element in the left-most position.
     syntax iterator for {init := 1; range := 1};
     {-# inline: 0 #-}
     for : {B : Type} -> (B -> elem -> B) -> B -> container -> B;

--- a/Stdlib/Trait/Foldable/Monomorphic.juvix
+++ b/Stdlib/Trait/Foldable/Monomorphic.juvix
@@ -1,0 +1,43 @@
+module Stdlib.Trait.Foldable.Monomorphic;
+
+import Stdlib.Function open;
+import Stdlib.Trait.Foldable.Polymorphic as Poly;
+
+--- A trait for combining elements into a single result, processing one element at a time.
+trait
+type Foldable (container elem : Type) :=
+  mkFoldable {-- Combine the elements of the type using the provided function starting with the element in the left-most position.
+  foldl : {B : Type} -> (B -> elem -> B) -> B -> container -> B};
+
+open Foldable;
+
+--- Make a monomorphic ;Foldable; instance from a polymorphic one.
+--- All polymorphic types that are an instance of ;Poly.Foldable; should use this function to create their monomorphic ;Foldable; instance.
+fromPolymorphicFoldable {f : Type -> Type} {{Poly.Foldable f}} {elem} : Foldable (f elem) elem :=
+  mkFoldable@{
+    foldl : {B : Type} -> (B -> elem -> B) -> B ->  f elem -> B := Poly.foldl
+  };
+
+--- Combine the elements of the type using the provided function starting with the element in the right-most position.
+foldr
+  {container elem : Type}
+  {{Foldable container elem}}
+  {B : Type}
+  (g : elem -> B -> B)
+  : B -> container -> B := foldl (flip g);
+
+syntax iterator for {init := 1; range := 1};
+
+{-# inline: 0 #-}
+for
+  {container elem : Type}
+  {B}
+  {{Foldable container elem}}
+  : (B -> elem -> B) -> B -> container -> B := foldl;
+
+syntax iterator rfor {init := 1; range := 1};
+
+{-# inline: 0 #-}
+rfor
+  {container elem : Type} {B} {{Foldable container elem}} (i : B → elem → B) : B → container → B :=
+  foldr (flip i);

--- a/Stdlib/Trait/Foldable/Monomorphic.juvix
+++ b/Stdlib/Trait/Foldable/Monomorphic.juvix
@@ -13,9 +13,10 @@ open Foldable;
 
 --- Make a monomorphic ;Foldable; instance from a polymorphic one.
 --- All polymorphic types that are an instance of ;Poly.Foldable; should use this function to create their monomorphic ;Foldable; instance.
-fromPolymorphicFoldable {f : Type -> Type} {{Poly.Foldable f}} {elem} : Foldable (f elem) elem :=
+fromPolymorphicFoldable
+  {f : Type -> Type} {{foldable : Poly.Foldable f}} {elem} : Foldable (f elem) elem :=
   mkFoldable@{
-    foldl : {B : Type} -> (B -> elem -> B) -> B ->  f elem -> B := Poly.foldl
+    foldl : {B : Type} -> (B -> elem -> B) -> B -> f elem -> B := Poly.foldl
   };
 
 --- Combine the elements of the type using the provided function starting with the element in the right-most position.

--- a/Stdlib/Trait/Foldable/Polymorphic.juvix
+++ b/Stdlib/Trait/Foldable/Polymorphic.juvix
@@ -1,0 +1,25 @@
+module Stdlib.Trait.Foldable.Polymorphic;
+
+import Stdlib.Function open;
+
+--- A trait for combining elements into a single result, processing one element at a time.
+trait
+type Foldable (f : Type -> Type) :=
+  mkFoldable {-- Combine the elements of the type using the provided function starting with the element in the left-most position.
+  foldl : {A B : Type} -> (B -> A -> B) -> B -> f A -> B};
+
+open Foldable public;
+
+--- Combine the elements of the type using the provided function starting with the element in the right-most position.
+foldr {f : Type -> Type} {{Foldable f}} {A B : Type} (g : A -> B -> B) : B -> f A -> B :=
+  foldl (flip g);
+
+syntax iterator for {init := 1; range := 1};
+
+{-# inline: 0 #-}
+for {f : Type -> Type} {A B} {{Foldable f}} : (B -> A -> B) -> B -> f A -> B := foldl;
+
+syntax iterator rfor {init := 1; range := 1};
+
+{-# inline: 0 #-}
+rfor {f : Type -> Type} {A B} {{Foldable f}} (i : B → A → B) : B → f A → B := foldr (flip i);

--- a/Stdlib/Trait/Foldable/Polymorphic.juvix
+++ b/Stdlib/Trait/Foldable/Polymorphic.juvix
@@ -18,7 +18,7 @@ type Foldable (f : Type -> Type) :=
 
 open Foldable public;
 
---- Combine the elements of the type using the provided function starting with the element in the right-most position.
+--- Combine the elements of the type using the provided function starting with the element in the left-most position.
 foldl {f : Type -> Type} {{Foldable f}} {A B : Type} (g : B -> A -> B) (ini : B) (ls : f A) : B :=
   for (acc := ini) (x in ls) {g acc x};
 

--- a/Stdlib/Trait/Foldable/Polymorphic.juvix
+++ b/Stdlib/Trait/Foldable/Polymorphic.juvix
@@ -6,7 +6,6 @@ import Stdlib.Function open;
 trait
 type Foldable (f : Type -> Type) :=
   mkFoldable {
-    -- Combine the elements of the type using the provided function starting with the element in the left-most position.
     syntax iterator for {init := 1; range := 1};
     {-# inline: 0 #-}
     for : {A B : Type} -> (B -> A -> B) -> B -> f A -> B;

--- a/Stdlib/Trait/Foldable/Polymorphic.juvix
+++ b/Stdlib/Trait/Foldable/Polymorphic.juvix
@@ -5,21 +5,23 @@ import Stdlib.Function open;
 --- A trait for combining elements into a single result, processing one element at a time.
 trait
 type Foldable (f : Type -> Type) :=
-  mkFoldable {-- Combine the elements of the type using the provided function starting with the element in the left-most position.
-  foldl : {A B : Type} -> (B -> A -> B) -> B -> f A -> B};
+  mkFoldable {
+    -- Combine the elements of the type using the provided function starting with the element in the left-most position.
+    syntax iterator for {init := 1; range := 1};
+    {-# inline: 0 #-}
+    for : {A B : Type} -> (B -> A -> B) -> B -> f A -> B;
+
+    syntax iterator rfor {init := 1; range := 1};
+    {-# inline: 0 #-}
+    rfor : {A B : Type} -> (B → A → B) -> B → f A → B
+  };
 
 open Foldable public;
 
 --- Combine the elements of the type using the provided function starting with the element in the right-most position.
-foldr {f : Type -> Type} {{Foldable f}} {A B : Type} (g : A -> B -> B) : B -> f A -> B :=
-  foldl (flip g);
+foldl {f : Type -> Type} {{Foldable f}} {A B : Type} (g : B -> A -> B) (ini : B) (ls : f A) : B :=
+  for (acc := ini) (x in ls) {g acc x};
 
-syntax iterator for {init := 1; range := 1};
-
-{-# inline: 0 #-}
-for {f : Type -> Type} {A B} {{Foldable f}} : (B -> A -> B) -> B -> f A -> B := foldl;
-
-syntax iterator rfor {init := 1; range := 1};
-
-{-# inline: 0 #-}
-rfor {f : Type -> Type} {A B} {{Foldable f}} (i : B → A → B) : B → f A → B := foldr (flip i);
+--- Combine the elements of the type using the provided function starting with the element in the right-most position.
+foldr {f : Type -> Type} {{Foldable f}} {A B : Type} (g : A -> B -> B) (ini : B) (ls : f A) : B :=
+  rfor (acc := ini) (x in ls) {g x acc};


### PR DESCRIPTION
- Closes #110.

# Polymorphic Foldable
This trait is equivalent to the `Foldable` class we all know in Haskell.
```
trait
type Foldable (f : Type -> Type) :=
  mkFoldable {-- Combine the elements of the type using the provided function starting with the element in the left-most position.
  foldl : {A B : Type} -> (B -> A -> B) -> B -> f A -> B};
```

# Monomorphic Foldable
This trait is similar to the [`MonoFoldable`](https://hackage.haskell.org/package/mono-traversable-1.0.17.0/docs/Data-MonoTraversable.html#t:MonoFoldable) class from the mono-traversable package. This trait is convenient because it can be instantiated by monomorphic (or restricted) types such as `Text`, `Bytes`, `Range N`.
```
trait
type Foldable (container elem : Type) :=
  mkFoldable {-- Combine the elements of the type using the provided function starting with the element in the left-most position.
  foldl : {B : Type} -> (B -> elem -> B) -> B -> container -> B};
```
This trait has two type parameters, `container` (e.g. `Text`) and `elem` (e.g. `Char`).

All types that are instances of `PolymorphicFoldable`, should have `Monomorphic` instances implemented via `fromPolymorphicFoldable`

As a consequence, the prelude will export the monomorphic version as `Foldable` and the polymorphic version as `Polymorphic.Foldable`.


# Problems with having both Polymorphic and Monomorphic versions
## Limited types
Ideally, in the monomorphic version we'd want to compute `elem` from `container` in some way. E.g.
```
trait
type FoldableImproved (container : Type) :=
  mkFoldable {
    elem : Type;
    foldl : {B : Type} -> (B -> elem -> B) -> B -> container -> B
  };
```
But this is not possible at the moment.


