### PR TITLE
Losen the Constraints on the Partial Trait

### DIFF
--- a/Stdlib/Data/List.juvix
+++ b/Stdlib/Data/List.juvix
@@ -16,11 +16,6 @@ import Stdlib.Trait.Foldable open using {
   fromPolymorphicFoldable;
 };
 
---- 𝒪(1). Partial function that returns the first element of a ;List;.
-phead {A} {{Partial}} : List A -> A
-  | (x :: _) := x
-  | nil := fail "head: empty list";
-
 instance
 eqListI {A} {{Eq A}} : Eq (List A) :=
   let

--- a/Stdlib/Data/List/Base.juvix
+++ b/Stdlib/Data/List/Base.juvix
@@ -7,6 +7,7 @@ import Stdlib.Function open;
 import Stdlib.Data.Nat.Base open;
 import Stdlib.Data.Maybe.Base open;
 import Stdlib.Trait.Ord open;
+import Stdlib.Trait.Partial open;
 import Stdlib.Data.Pair.Base open;
 
 --- 𝒪(𝓃). Returns ;true; if the given object elem is in the ;List;.
@@ -164,6 +165,11 @@ head {A} (defaultValue : A) (list : List A) : A :=
   case list of
     | x :: _ := x
     | nil := defaultValue;
+
+--- 𝒪(1). Partial function that returns the first element of a ;List;.
+phead {A} {{Partial}} : List A -> A
+  | (x :: _) := x
+  | nil := fail "head: empty list";
 
 syntax iterator any {init := 0; range := 1};
 

--- a/Stdlib/Debug/Fail.juvix
+++ b/Stdlib/Debug/Fail.juvix
@@ -1,6 +1,6 @@
 module Stdlib.Debug.Fail;
 
-import Stdlib.Data.String.Base open;
+import Juvix.Builtin.V1.String open;
 
 --- Exit the program with an error message.
 builtin fail

--- a/Stdlib/Trait/Partial.juvix
+++ b/Stdlib/Trait/Partial.juvix
@@ -1,6 +1,6 @@
 module Stdlib.Trait.Partial;
 
-import Stdlib.Data.String.Base open;
+import Juvix.Builtin.V1.String open;
 import Stdlib.Debug.Fail as Debug;
 
 trait


### PR DESCRIPTION
Partial trait relied upon

import Stdlib.Data.String.Base open;

which indirectly relies upon list, we loosen the restriction to just
rely on the String type itself.

This lets us move some functions around to the base module
