### PR TITLE
Add (poly and mono) traversable implementation, along with basic instances

### DIFF
--- a/Stdlib/Data/List.juvix
+++ b/Stdlib/Data/List.juvix
@@ -15,6 +15,7 @@ import Stdlib.Trait.Foldable open using {
   module Polymorphic;
   fromPolymorphicFoldable;
 };
+import Stdlib.Trait.Traversable open;
 
 --- 𝒪(1). Partial function that returns the first element of a ;List;.
 phead {A} {{Partial}} : List A -> A
@@ -103,4 +104,15 @@ instance
 monadListI : Monad List :=
   mkMonad@{
     bind := flip concatMap;
+  };
+
+instance
+traversableListI : Traversable List :=
+  mkTraversable@{
+    terminating
+    sequenceA {F : Type -> Type} {{_ : Applicative F}} {A} (xs : List (F A)) : F (List A) :=
+      case xs of
+        | nil := pure nil
+        | (x :: xs) := liftA2 (::) x (sequenceA xs);
+    traverse := defaultTraverse sequenceA;
   };

--- a/Stdlib/Data/Maybe.juvix
+++ b/Stdlib/Data/Maybe.juvix
@@ -8,6 +8,7 @@ import Stdlib.Trait.Show open;
 import Stdlib.Trait.Functor open;
 import Stdlib.Trait.Applicative open;
 import Stdlib.Trait.Monad open;
+import Stdlib.Trait.Traversable open;
 
 import Stdlib.Data.Bool.Base open;
 import Stdlib.Data.String.Base open;
@@ -61,4 +62,13 @@ monadMaybeI : Monad Maybe :=
       case maybe of
         | nothing := nothing
         | just a := fun a;
+  };
+
+instance
+traversableMaybeI : Traversable Maybe :=
+  mkTraversable@{
+    sequenceA {F : Type -> Type} {{_ : Applicative F}} {A} : Maybe (F A) -> F (Maybe A)
+      | nothing := pure nothing
+      | (just x) := map just x;
+    traverse := defaultTraverse sequenceA;
   };

--- a/Stdlib/Data/Result.juvix
+++ b/Stdlib/Data/Result.juvix
@@ -8,6 +8,7 @@ import Stdlib.Data.Pair.Base open;
 import Stdlib.Trait.Eq open;
 import Stdlib.Trait.Ord open;
 import Stdlib.Trait.Show open;
+import Stdlib.Trait.Traversable open;
 import Stdlib.Trait open;
 
 {-# specialize: true, inline: case #-}
@@ -66,4 +67,13 @@ monadResultI {Error} : Monad (Result Error) :=
       case result of
         | error e := error e
         | ok a := fun a;
+  };
+
+instance
+traversableResultI {E} : Traversable (Result E) :=
+  mkTraversable@{
+    sequenceA {F : Type -> Type} {{_ : Applicative F}} {A} : Result E (F A) -> F (Result E A)
+      | (error e) := pure (error e)
+      | (ok x) := map ok x;
+    traverse := defaultTraverse sequenceA;
   };

--- a/Stdlib/Trait.juvix
+++ b/Stdlib/Trait.juvix
@@ -7,6 +7,7 @@ import Stdlib.Trait.Functor open public;
 import Stdlib.Trait.Applicative open public;
 import Stdlib.Trait.Monad open public;
 import Stdlib.Trait.Foldable open public;
+import Stdlib.Trait.Traversable open public;
 import Stdlib.Trait.Partial open public;
 import Stdlib.Trait.Natural open public;
 import Stdlib.Trait.FromNatural open public;

--- a/Stdlib/Trait/Traversable.juvix
+++ b/Stdlib/Trait/Traversable.juvix
@@ -1,0 +1,4 @@
+module Stdlib.Trait.Traversable;
+
+import Stdlib.Trait.Traversable.Polymorphic open public;
+import Stdlib.Trait.Traversable.Monomorphic as MonoTraversable public;

--- a/Stdlib/Trait/Traversable/Monomorphic.juvix
+++ b/Stdlib/Trait/Traversable/Monomorphic.juvix
@@ -1,0 +1,27 @@
+module Stdlib.Trait.Traversable.Monomorphic;
+
+import Stdlib.Function open;
+import Stdlib.Trait.Traversable.Polymorphic as Poly;
+import Stdlib.Trait.Functor.Monomorphic open;
+import Stdlib.Trait.Applicative open;
+
+trait
+type Traversable (Container Elem : Type) :=
+  mkTraversable@{
+    {{functorI}} : Functor Container Elem;
+    traverse : {F : Type -> Type} -> {{Applicative F}} ->
+               (Elem -> F Elem) -> Container -> F Container;
+  };
+
+open Traversable public;
+
+--- Make a monomorphic Traversable instance from a polymorphic one.
+fromPolymorphicTraversable
+  {T : Type -> Type}
+  {{traversable : Poly.Traversable T}}
+  {Elem}
+  : Traversable (T Elem) Elem :=
+  mkTraversable@{
+    functorI := fromPolymorphicFunctor;
+    traverse := \{f ta := Poly.traverse f ta};
+  };

--- a/Stdlib/Trait/Traversable/Polymorphic.juvix
+++ b/Stdlib/Trait/Traversable/Polymorphic.juvix
@@ -1,0 +1,33 @@
+module Stdlib.Trait.Traversable.Polymorphic;
+
+import Stdlib.Function open;
+import Stdlib.Trait.Functor.Polymorphic open;
+import Stdlib.Trait.Applicative open;
+
+--- A trait for traversing a structure while performing applicative effects
+trait
+type Traversable (T : Type -> Type) := 
+  mkTraversable@{
+    {{functorI}} : Functor T;
+    traverse : {F : Type -> Type} -> {{Applicative F}} -> 
+               {A B : Type} -> (A -> F B) -> T A -> F (T B);
+    sequenceA : {F : Type -> Type} -> {{Applicative F}} ->
+                {A : Type} -> T (F A) -> F (T A);
+  };
+
+open Traversable public;
+
+-- Default implementation of sequenceA using traverse
+defaultSequenceA 
+  {T : Type -> Type} {F : Type -> Type} {{Applicative F}} {A : Type}
+  (trav : {F : Type -> Type} -> {{Applicative F}} -> 
+          {A B : Type} -> (A -> F B) -> T A -> F (T B))
+  (tfa : T (F A)) : F (T A) := trav id tfa;
+
+-- Default implementation of traverse using sequenceA  
+defaultTraverse
+  {T : Type -> Type} {{Functor T}} {F : Type -> Type} {{Applicative F}} {A B : Type}
+  (seqA : {F : Type -> Type} -> {{Applicative F}} ->
+          {A : Type} -> T (F A) -> F (T A))
+  (f : A -> F B) (ta : T A) : F (T B) := 
+  seqA (map f ta);


### PR DESCRIPTION
Adds Traversable implementation, including both polymorphic and monomorphic implementations. Also adds instances for `List`, `Maybe`, and `Result E`.

Right now, Traversable.juvix exports the polymorphic version with the monomorphic version qualified as `MonoTraversable`; it may be desirable to change this.

Came up in the context of discussion here: https://github.com/anoma/nspec/pull/302#discussion_r1900544954