### PR TITLE
Export Set and Map types from the Prelude

### DIFF
--- a/Stdlib/Data/Set.juvix
+++ b/Stdlib/Data/Set.juvix
@@ -33,14 +33,14 @@ type Set (A : Type) :=
     };
 
 module Internal;
-  --- 𝒪(1) Retrieves the height of an ;Set;. The height is the distance from
+  --- 𝒪(1) Retrieves the height of a ;Set;. The height is the distance from
   --- the root to the deepest child.
   height {A} (set : Set A) : Nat :=
     case set of
       | empty := 0
       | node@{height} := height;
 
-  --- 𝒪(n). Maps a function over an ;Set;. Does not check if
+  --- 𝒪(n). Maps a function over a ;Set;. Does not check if
   --- after mapping the order of the elements is preserved. It is the
   --- responsibility of the caller to ensure that `f` preserves the ordering.
   unsafeMap {A B} (f : A -> B) (set : Set A) : Set B :=

--- a/Stdlib/Prelude.juvix
+++ b/Stdlib/Prelude.juvix
@@ -18,5 +18,16 @@ import Stdlib.Data.Range open public;
 import Stdlib.Function open public;
 import Stdlib.System.IO open public;
 import Stdlib.Debug.Todo open public;
-
 import Stdlib.Trait open public;
+
+module Map;
+  import Stdlib.Data.Map open public;
+end;
+
+open Map using {Map} public;
+
+module Set;
+  import Stdlib.Data.Set open public;
+end;
+
+open Set using {Set} public;


### PR DESCRIPTION
The types `Set` and `Map` are now exported from the Prelude. Additionally, it is possible to refer to Map operations with Map.* and Set.*. E.g. 
```
import Stdlib.Prelude;

a : Set Nat := Set.empty;
a : Map Nat Nat := Map.empty;
```